### PR TITLE
Fix CI TagLib on macOS 11 and Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,6 @@ jobs:
       matrix:
         python-version: [3.8, 3.9, '3.10']
         os: [ubuntu-latest, ubuntu-18.04, macos-latest, windows-latest]
-        exclude:
-          - os: macos-latest
-            python-version: '3.10'
     runs-on: ${{ matrix.os }}
     env:
       TAGLIB_HOME: taglib-install
@@ -24,6 +21,12 @@ jobs:
       - name: Install TagLib (Linux/MacOS)
         if: ${{ runner.os != 'Windows' }}
         run: if [ "$RUNNER_OS" = "Linux" ]; then sudo apt-get install -y libtag1-dev ; else brew install taglib ; fi
+
+      - name: Fix TagLib on macOS 11 with Python 3.10
+        if: matrix.os == 'macos-latest' && matrix.python-version == '3.10'
+        run: |
+          rsync -avP $(brew --prefix taglib)/include/ /usr/local/opt/sqlite/include/
+          rsync -avP $(brew --prefix taglib)/lib/ /usr/local/opt/sqlite/lib/
 
       - name: Install Poetry
         uses: abatilo/actions-poetry@v2.0.0


### PR DESCRIPTION
Seems like macOS 11 and Python 3.11 don't look into /usr/local/include and /usr/local/lib for libraries as do other versions. This adds a hacky workaround by copying TagLibs files into a directory it *does* look into (/usr/local/opt/sqlite).

Ref: https://github.com/supermihi/pytaglib/issues/105