### PR TITLE
v0.9.4 - Fix process abort on undecodable image metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Changelog
 
+## 0.9.4 - 2026-07-09
+
+- Fixed process abort (uncatchable `std::terminate` → SIGABRT) in `image_meta_extract()` when an
+    image carries a metadata value that exiv2 cannot convert to UTF-8, e.g. an EXIF `UserComment`
+    declared UNICODE with an invalid UTF-16 payload as written by some early-2000s digital cameras;
+    undecodable fields are now skipped with a warning instead of crashing the process
+
 ## 0.9.3 - 2026-06-04
 
 - Added SVG cover image support for EPUB thumbnails (rasterized via `resvg`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,12 @@
 ## Changelog
 
+## 0.9.4 - 2026-07-09
+
+- Fixed process abort (uncatchable `std::terminate` → SIGABRT) in `image_meta_extract()` when an
+    image carries a metadata value that exiv2 cannot convert to UTF-8, e.g. an EXIF `UserComment`
+    declared UNICODE with an invalid UTF-16 payload as written by some early-2000s digital cameras;
+    undecodable fields are now skipped with a warning instead of crashing the process
+
 ## 0.9.3 - 2026-06-04
 
 - Added SVG cover image support for EPUB thumbnails (rasterized via `resvg`)

--- a/iscc_sdk/image.py
+++ b/iscc_sdk/image.py
@@ -366,14 +366,14 @@ def _process_metadata(metadata, is_xmp=False):
     result = {}
     for datum in metadata:
         key = datum.key()
-        raw_value = datum.value
-        value = raw_value() if callable(raw_value) else raw_value
-
-        if not isinstance(value, str):
-            if hasattr(value, "to_string"):
-                value = value.to_string()
-            else:
-                value = str(value)
+        try:
+            # Metadatum.toString() raises a catchable exiv2.Exiv2Error on values that
+            # cannot be converted to UTF-8, while str(datum.value()) escalates the same
+            # C++ exception to std::terminate and aborts the process.
+            value = datum.toString()
+        except Exception as e:
+            log.warning(f"Skipping unreadable metadata field {key}: {e}")
+            continue
 
         value = value.strip()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iscc-sdk"
-version = "0.9.3"
+version = "0.9.4"
 description = "SDK for creating ISCCs (International Standard Content Codes)"
 authors = [{ name = "Titusz", email = "tp@py7.de" }]
 requires-python = ">=3.11"

--- a/tests/test_epub.py
+++ b/tests/test_epub.py
@@ -83,9 +83,9 @@ def test_embed_metadata_with_epub(epub_file):
 
 
 class _RawNameZipInfo(zipfile.ZipInfo):
-    """ZipInfo that writes pre-encoded raw filename bytes without forcing
-    the ZIP UTF-8 flag (bit 11). Used to reproduce real-world EPUBs whose
-    packagers stored UTF-8 filename bytes in CP437-flagged entries.
+    """ZipInfo that writes pre-encoded raw filename bytes without the ZIP
+    UTF-8 flag (bit 11). Used to reproduce real-world EPUBs whose packagers
+    stored UTF-8 filename bytes in CP437-flagged entries.
     """
 
     def __init__(self, raw_bytes):
@@ -93,7 +93,10 @@ class _RawNameZipInfo(zipfile.ZipInfo):
         self._raw_bytes = raw_bytes
 
     def _encodeFilenameFlags(self):
-        return self._raw_bytes, self.flag_bits
+        # Newer CPython (zip-spoofing hardening in 3.13.x/3.14) stamps the
+        # UTF-8 flag into flag_bits in ZipFile.open(mode="w") before this
+        # hook runs, so the bit must be cleared here rather than assumed 0.
+        return self._raw_bytes, self.flag_bits & ~0x800
 
 
 _DEFAULT_CONTAINER = (

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import os.path
+import exiv2
 from PIL import Image, ImageDraw
 
 import iscc_sdk as idk
@@ -348,36 +349,52 @@ def test_clean_xmp_value():
     assert idk.image._clean_xmp_value(value) == 'lang="x-default'
 
 
-def test_process_metadata_to_string():
-    """Test that non-string values with to_string method are properly converted."""
+def test_process_metadata_skips_unreadable():
+    """Test that datums whose toString() raises are skipped without failing extraction."""
 
-    # Create a simple class that simulates an exiv2 metadata value with to_string method
-    class MockToString:
-        def to_string(self):
-            return "converted string value"
-
-    # Create a mock datum that simulates the exiv2 metadata datum structure
+    # Create mock datums that simulate the exiv2 metadata datum structure
     class MockDatum:
-        def __init__(self, key, value):
+        def __init__(self, key, value=None, error=None):
             self._key = key
             self._value = value
+            self._error = error
 
         def key(self):
             return self._key
 
-        @property
-        def value(self):
+        def toString(self):
+            if self._error:
+                raise self._error
             return self._value
 
-    # Create test data
-    mock_value = MockToString()
-    mock_datum = MockDatum("Test.Key", mock_value)
+    good = MockDatum("Test.Good", " some value ")
+    bad = MockDatum("Test.Bad", error=RuntimeError("cannot convert"))
 
-    # Call the function with our mock data
-    result = idk.image._process_metadata([mock_datum])
+    result = idk.image._process_metadata([good, bad])
 
-    # Verify the result
-    assert result["Test.Key"] == "converted string value"
+    assert result == {"Test.Good": "some value"}
+
+
+def test_image_meta_extract_undecodable_exif(tmp_path):
+    """A field exiv2 cannot convert to UTF-8 must not abort extraction (issue: SIGABRT).
+
+    Regression test for a process abort (std::terminate, uncatchable from Python) on
+    images with an EXIF UserComment declared as UNICODE but holding an odd-length
+    payload (invalid UTF-16), as written by some early-2000s digital cameras.
+    """
+    fp = tmp_path / "undecodable.jpg"
+    Image.new("RGB", (4, 4)).save(fp, "JPEG")
+
+    img = exiv2.ImageFactory.open(fp.as_posix())
+    img.readMetadata()
+    # 8-byte "UNICODE\0" charset header + odd 1-byte payload -> iconv failure on read
+    payload = b"UNICODE\x00A"
+    value = exiv2.DataValue(exiv2.TypeId.undefined)
+    value.read(" ".join(str(byte) for byte in payload))
+    img.exifData()["Exif.Photo.UserComment"] = value
+    img.writeMetadata()
+
+    assert idk.image_meta_extract(fp) == {"width": 4, "height": 4}
 
 
 def test_code_image_nometa_nothumb(jpg_file, monkeypatch):

--- a/tests/test_iscc_sdk.py
+++ b/tests/test_iscc_sdk.py
@@ -2,4 +2,4 @@ from iscc_sdk import __version__
 
 
 def test_version():
-    assert __version__ == "0.9.3"
+    assert __version__ == "0.9.4"

--- a/uv.lock
+++ b/uv.lock
@@ -731,7 +731,7 @@ wheels = [
 
 [[package]]
 name = "iscc-sdk"
-version = "0.9.3"
+version = "0.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "bitarray" },


### PR DESCRIPTION
## Summary

Release v0.9.4 — fixes a process-abort bug reported against `code_meta()` / `image_meta_extract()`.

A single image whose EXIF contains a value in a text encoding exiv2 cannot convert to UTF-8 (e.g. a `UserComment` declared UNICODE/UCS-2 with an odd-length payload) crashed the **entire Python process** with an uncatchable native abort (`std::terminate` → SIGABRT on macOS/Linux, `0xC0000409` on Windows). Callers could not protect themselves with `try/except`. Real-world images trigger this — e.g. early-2000s digital-camera JPEGs with UCS-2 UserComments (reproduced with [File:Bernhard_Richter.jpg](https://commons.wikimedia.org/wiki/File:Bernhard_Richter.jpg) from Wikimedia Commons).

## Root cause

`_process_metadata()` stringified metadata values via `str(datum.value())`. For the offending field the value is a `CommentValue` (which has no `to_string` attribute), and the `Value.__str__` binding in python-exiv2 does not translate the C++ `Exiv2::Error` raised by the failed iconv conversion, so it escalates to `std::terminate`. The sibling API `Metadatum.toString()` raises a **catchable** `exiv2.Exiv2Error` for the same value.

## Changes

- `_process_metadata()` now stringifies each datum via `datum.toString()` guarded per field — undecodable fields are skipped with a warning instead of crashing the process
- Regression test synthesizing the malformed EXIF UserComment with existing dependencies only (PIL + exiv2)
- Updated the mock-based `_process_metadata` unit test to the new contract (including the skip path)
- Version bump 0.9.3 → 0.9.4, changelog updated

## Verification

- Extraction output is byte-identical to the previous implementation across all iscc-samples images (EXIF, XMP, and IPTC paths)
- Both previously-crashing files (synthetic + Wikimedia sample) now extract cleanly with correct name/dimensions
- `poe all` green locally: lint, docs build, 337 tests passed, 100% coverage maintained